### PR TITLE
`db`.`column` References in the Order part of a query parse correctly.

### DIFF
--- a/src/PHPSQL/Parser/Utils.php
+++ b/src/PHPSQL/Parser/Utils.php
@@ -64,6 +64,7 @@ class Utils extends \PHPSQL\Parser\Constants {
         if (($result[0] === '`') && ($result[strlen($result) - 1] === '`')) {
             $result = substr($result, 1, -1);
         }
+        $result = str_replace('`.`', '.', $result);
         return str_replace('``', '`', $result);
     }
 


### PR DESCRIPTION
This query: SELECT `NovaLog`.`id`, `NovaLog`.`type`, `NovaLog`.`message`, `NovaLog`.`email_sent`, `NovaLog`.`hide`, `NovaLog`.`created`, `NovaLog`.`modified` FROM `meridian-dc`.`nova_logs` AS `NovaLog`   WHERE `email_sent` = '1'   ORDER BY `NovaLog`.`created` DESC  LIMIT 1

Would not parse correctly.  I did a quick fix that gets it parsing, but I didn't run the test suite yet.  I don't have time to checkout the project, run the tests, etc...  (My environment isn't setup for composer at the moment), but I wanted to send you the fix / make you aware of the problem.

Joey
