### PR TITLE
process reserved subtrees (case when exists etc)

### DIFF
--- a/src/PHPSQL/Creator.php
+++ b/src/PHPSQL/Creator.php
@@ -450,6 +450,7 @@ class Creator {
             $sql .= $this->processSubQuery($v);
             $sql .= $this->processSelectBracketExpression($v);
             $sql .= $this->processReserved($v);
+            $sql .= $this->processColRef($v);
 
             if ($len == strlen($sql)) {
                 throw new \PHPSQL\Exception\UnableToCreateSQL('expression subtree', $k, $v, 'expr_type');
@@ -471,6 +472,7 @@ class Creator {
             $sql .= $this->processColRef($v);
             $sql .= $this->processOperator($v);
             $sql .= $this->processConstant($v);
+            $sql .= $this->processFunction($v);
 
             if ($len == strlen($sql)) {
                 throw new \PHPSQL\Exception\UnableToCreateSQL('expression ref_clause', $k, $v, 'expr_type');

--- a/src/PHPSQL/Creator.php
+++ b/src/PHPSQL/Creator.php
@@ -413,8 +413,8 @@ class Creator {
             if ($len == strlen($sql)) {
                 throw new \PHPSQL\Exception\UnableToCreateSQL('function subtree', $k, $v, 'expr_type');
             }
-
-            $sql .= ($this->isReserved($v) ? " " : ",");
+            $sql .= ($this->isReserved($v) || ($parsed['base_expr'] == 'CAST')
+                     ? " " : ",");
         }
         return $parsed['base_expr'] . "(" . substr($sql, 0, -1) . ")";
     }

--- a/src/PHPSQL/Creator.php
+++ b/src/PHPSQL/Creator.php
@@ -449,6 +449,7 @@ class Creator {
             $sql .= $this->processConstant($v);
             $sql .= $this->processSubQuery($v);
             $sql .= $this->processSelectBracketExpression($v);
+            $sql .= $this->processReserved($v);
 
             if ($len == strlen($sql)) {
                 throw new \PHPSQL\Exception\UnableToCreateSQL('expression subtree', $k, $v, 'expr_type');


### PR DESCRIPTION
I had a column that looked like
`CASE WHEN EXISTS(
                   SELECT id FROM payments 
                    WHERE payments.payment_key = rental_applications.payment_key
                      AND payments.status = 'ACCEPT') THEN '1' ELSE '0' END as is_paid,` 

that when parsed would not unparse without this patch
